### PR TITLE
Move alert description validation to be optional

### DIFF
--- a/pkg/testutil/alert_custom_validation_test.go
+++ b/pkg/testutil/alert_custom_validation_test.go
@@ -32,8 +32,8 @@ var _ = Describe("Custom Validators", func() {
 					"runbook_url": "example/runbook/url",
 				},
 			}
-			linter.AddCustomAlertValidations(ValidateAlertNameLength, ValidateAlertRunbookURLAnnotation,
-				ValidateAlertHealthImpactLabel, ValidateAlertPartOfAndComponentLabels)
+			linter.AddCustomAlertValidations(ValidateAlertNameLength, ValidateAlertHasDescriptionAnnotation,
+				ValidateAlertRunbookURLAnnotation, ValidateAlertHealthImpactLabel, ValidateAlertPartOfAndComponentLabels)
 			problems := linter.LintAlert(alert)
 			Expect(problems).To(BeEmpty())
 		})
@@ -46,14 +46,30 @@ var _ = Describe("Custom Validators", func() {
 					"severity": "critical",
 				},
 				Annotations: map[string]string{
-					"summary":     "Example summary",
-					"description": "Example description",
+					"summary": "Example summary",
 				},
 			}
 			linter.AddCustomAlertValidations(ValidateAlertNameLength)
 			problems := linter.LintAlert(alert)
 			Expect(problems).To(HaveLen(1))
 			Expect(problems[0].Description).To(ContainSubstring("alert name exceeds 50 characters"))
+		})
+
+		It("should return error if description custom validation was added and is missing", func() {
+			alert := &promv1.Rule{
+				Alert: "ExampleAlert",
+				Expr:  intstr.FromString("sum(rate(http_requests_total[5m]))"),
+				Labels: map[string]string{
+					"severity": "critical",
+				},
+				Annotations: map[string]string{
+					"summary": "Example summary",
+				},
+			}
+			linter.AddCustomAlertValidations(ValidateAlertHasDescriptionAnnotation)
+			problems := linter.LintAlert(alert)
+			Expect(problems).To(HaveLen(1))
+			Expect(problems[0].Description).To(ContainSubstring("alert must have a description annotation"))
 		})
 
 		It("should return error if runbook_url custom validation was added and is missing", func() {
@@ -64,8 +80,7 @@ var _ = Describe("Custom Validators", func() {
 					"severity": "critical",
 				},
 				Annotations: map[string]string{
-					"summary":     "Example summary",
-					"description": "Example description",
+					"summary": "Example summary",
 				},
 			}
 			linter.AddCustomAlertValidations(ValidateAlertRunbookURLAnnotation)
@@ -83,8 +98,7 @@ var _ = Describe("Custom Validators", func() {
 					"operator_health_impact": "invalid_operator_health_impact",
 				},
 				Annotations: map[string]string{
-					"summary":     "Example summary",
-					"description": "Example description",
+					"summary": "Example summary",
 				},
 			}
 			linter.AddCustomAlertValidations(ValidateAlertHealthImpactLabel)
@@ -101,8 +115,7 @@ var _ = Describe("Custom Validators", func() {
 					"severity": "critical",
 				},
 				Annotations: map[string]string{
-					"summary":     "Example summary",
-					"description": "Example description",
+					"summary": "Example summary",
 				},
 			}
 			linter.AddCustomAlertValidations(ValidateAlertPartOfAndComponentLabels)

--- a/pkg/testutil/alert_custom_validations.go
+++ b/pkg/testutil/alert_custom_validations.go
@@ -17,6 +17,20 @@ func ValidateAlertNameLength(alert *promv1.Rule) []Problem {
 	return result
 }
 
+func ValidateAlertHasDescriptionAnnotation(alert *promv1.Rule) []Problem {
+	var result []Problem
+
+	description := alert.Annotations["description"]
+	if description == "" {
+		result = append(result, Problem{
+			ResourceName: alert.Alert,
+			Description:  "alert must have a description annotation",
+		})
+	}
+
+	return result
+}
+
 func ValidateAlertRunbookURLAnnotation(alert *promv1.Rule) []Problem {
 	var result []Problem
 

--- a/pkg/testutil/alert_validation.go
+++ b/pkg/testutil/alert_validation.go
@@ -13,7 +13,6 @@ var defaultAlertValidations = []AlertValidation{
 	validateAlertHasExpression,
 	validateAlertHasSeverityLabel,
 	validateAlertHasSummaryAnnotation,
-	validateAlertHasDescriptionAnnotation,
 }
 
 func validateAlertName(alert *promv1.Rule) []Problem {
@@ -64,20 +63,6 @@ func validateAlertHasSummaryAnnotation(alert *promv1.Rule) []Problem {
 		result = append(result, Problem{
 			ResourceName: alert.Alert,
 			Description:  "alert must have a summary annotation",
-		})
-	}
-
-	return result
-}
-
-func validateAlertHasDescriptionAnnotation(alert *promv1.Rule) []Problem {
-	var result []Problem
-
-	description := alert.Annotations["description"]
-	if description == "" {
-		result = append(result, Problem{
-			ResourceName: alert.Alert,
-			Description:  "alert must have a description annotation",
 		})
 	}
 

--- a/pkg/testutil/alert_validation_test.go
+++ b/pkg/testutil/alert_validation_test.go
@@ -98,21 +98,5 @@ var _ = Describe("Default Validators", func() {
 			Expect(problems).To(HaveLen(1))
 			Expect(problems[0].Description).To(ContainSubstring("alert must have a summary annotation"))
 		})
-
-		It("should return error if description annotation is missing", func() {
-			alert := &promv1.Rule{
-				Alert: "ExampleAlert",
-				Expr:  intstr.FromString("sum(rate(http_requests_total[5m]))"),
-				Labels: map[string]string{
-					"severity": "critical",
-				},
-				Annotations: map[string]string{
-					"summary": "Example summary",
-				},
-			}
-			problems := linter.LintAlert(alert)
-			Expect(problems).To(HaveLen(1))
-			Expect(problems[0].Description).To(ContainSubstring("alert must have a description annotation"))
-		})
 	})
 })


### PR DESCRIPTION
Many alert rules have `summary` annotation, but not `description`, and this is valid, since `description` is not mandatory. This PR moves the alert description validation to be optional.