### PR TITLE
Ensure order of recording rule registration in PrometheusRule

### DIFF
--- a/pkg/operatorrules/prometheusrules.go
+++ b/pkg/operatorrules/prometheusrules.go
@@ -67,7 +67,9 @@ func buildRecordingRulesRules() []promv1.Rule {
 	}
 
 	slices.SortFunc(rules, func(a, b promv1.Rule) int {
-		return cmp.Compare(a.Record, b.Record)
+		aKey := a.Record + ":" + a.Expr.String()
+		bKey := b.Record + ":" + b.Expr.String()
+		return cmp.Compare(aKey, bKey)
 	})
 
 	return rules


### PR DESCRIPTION
It could happen that there are several
prometheus rules with the same name but different
expression.
Since the `range` in a for loop does not provide
always the same order, it could happen the
resulting prometheus rule list to be different.