### PR TITLE
Remove usage of global variable in operatorrules

### DIFF
--- a/_examples/rules/operator_alerts.go
+++ b/_examples/rules/operator_alerts.go
@@ -5,6 +5,7 @@ import (
 
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 )
 
 var operatorAlerts = []promv1.Rule{
@@ -22,7 +23,7 @@ var operatorAlerts = []promv1.Rule{
 	{
 		Alert: "GuestbookOperatorNotReady",
 		Expr:  intstr.FromString(fmt.Sprintf("%snumber_of_ready_pods < %snumber_of_pods", recordingRulesPrefix, recordingRulesPrefix)),
-		For:   "5m",
+		For:   ptr.To(promv1.Duration("5m")),
 		Annotations: map[string]string{
 			"summary":     "Guestbook operator is not ready",
 			"description": "Guestbook operator is not ready for more than 5 minutes.",

--- a/_examples/rules/rules.go
+++ b/_examples/rules/rules.go
@@ -12,6 +12,8 @@ const (
 )
 
 var (
+	operatorRegistry = operatorrules.NewRegistry()
+
 	// Add your custom recording rules here
 	recordingRules = [][]operatorrules.RecordingRule{
 		operatorRecordingRules,
@@ -24,19 +26,19 @@ var (
 )
 
 func SetupRules() {
-	err := operatorrules.RegisterRecordingRules(recordingRules...)
+	err := operatorRegistry.RegisterRecordingRules(recordingRules...)
 	if err != nil {
 		panic(err)
 	}
 
-	err = operatorrules.RegisterAlerts(alerts...)
+	err = operatorRegistry.RegisterAlerts(alerts...)
 	if err != nil {
 		panic(err)
 	}
 }
 
 func BuildPrometheusRule() (*promv1.PrometheusRule, error) {
-	rules, err := operatorrules.BuildPrometheusRule(
+	rules, err := operatorRegistry.BuildPrometheusRule(
 		"guestbook-operator-prometheus-rules",
 		"default",
 		map[string]string{"app": "guestbook-operator"},
@@ -49,9 +51,9 @@ func BuildPrometheusRule() (*promv1.PrometheusRule, error) {
 }
 
 func ListRecordingRules() []operatorrules.RecordingRule {
-	return operatorrules.ListRecordingRules()
+	return operatorRegistry.ListRecordingRules()
 }
 
 func ListAlerts() []promv1.Rule {
-	return operatorrules.ListAlerts()
+	return operatorRegistry.ListAlerts()
 }

--- a/pkg/operatorrules/compatibility.go
+++ b/pkg/operatorrules/compatibility.go
@@ -1,0 +1,37 @@
+package operatorrules
+
+import promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+
+// Deprecated: operatorRegistry is deprecated.
+var operatorRegistry = NewRegistry()
+
+// Deprecated: RegisterRecordingRules is deprecated.
+func RegisterRecordingRules(recordingRules ...[]RecordingRule) error {
+	return operatorRegistry.RegisterRecordingRules(recordingRules...)
+}
+
+// Deprecated: RegisterAlerts is deprecated.
+func RegisterAlerts(alerts ...[]promv1.Rule) error {
+	return operatorRegistry.RegisterAlerts(alerts...)
+}
+
+// Deprecated: ListRecordingRules is deprecated.
+func ListRecordingRules() []RecordingRule {
+	return operatorRegistry.ListRecordingRules()
+}
+
+// Deprecated: ListAlerts is deprecated.
+func ListAlerts() []promv1.Rule {
+	return operatorRegistry.ListAlerts()
+}
+
+// Deprecated: CleanRegistry is deprecated.
+func CleanRegistry() error {
+	operatorRegistry = NewRegistry()
+	return nil
+}
+
+// Deprecated: BuildPrometheusRule is deprecated.
+func BuildPrometheusRule(name, namespace string, labels map[string]string) (*promv1.PrometheusRule, error) {
+	return operatorRegistry.BuildPrometheusRule(name, namespace, labels)
+}

--- a/pkg/operatorrules/compatibility_test.go
+++ b/pkg/operatorrules/compatibility_test.go
@@ -1,0 +1,231 @@
+package operatorrules
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+
+	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
+)
+
+var _ = Describe("OperatorRules", func() {
+	BeforeEach(func() {
+		operatorRegistry = NewRegistry()
+	})
+
+	Context("RecordingRule Registration", func() {
+		It("should register recording rules without error", func() {
+			recordingRules := []RecordingRule{
+				{
+					MetricsOpts: operatormetrics.MetricOpts{Name: "ExampleRecordingRule1"},
+					Expr:        intstr.FromString("sum(rate(http_requests_total[5m]))"),
+				},
+				{
+					MetricsOpts: operatormetrics.MetricOpts{Name: "ExampleRecordingRule2"},
+					Expr:        intstr.FromString("sum(rate(http_requests_total[5m]))"),
+				},
+			}
+
+			err := RegisterRecordingRules(recordingRules)
+			Expect(err).To(BeNil())
+
+			registeredRules := ListRecordingRules()
+			Expect(registeredRules).To(ConsistOf(recordingRules))
+		})
+
+		It("should replace recording rule with the same name and expression", func() {
+			recordingRules := []RecordingRule{
+				{
+					MetricsOpts: operatormetrics.MetricOpts{Name: "ExampleRecordingRule1"},
+					Expr:        intstr.FromString("sum(rate(http_requests_total[5m]))"),
+				},
+				{
+					MetricsOpts: operatormetrics.MetricOpts{Name: "ExampleRecordingRule1"},
+					Expr:        intstr.FromString("sum(rate(http_requests_total[5m]))"),
+				},
+			}
+
+			err := RegisterRecordingRules(recordingRules)
+			Expect(err).To(BeNil())
+
+			registeredRules := ListRecordingRules()
+			Expect(registeredRules).To(HaveLen(1))
+			Expect(registeredRules[0].Expr.String()).To(Equal("sum(rate(http_requests_total[5m]))"))
+		})
+
+		It("should create 2 recording rules when registered with the same name but different expressions", func() {
+			recordingRules := []RecordingRule{
+				{
+					MetricsOpts: operatormetrics.MetricOpts{Name: "ExampleRecordingRule1"},
+					Expr:        intstr.FromString("sum(rate(http_requests_total[5m]))"),
+				},
+			}
+
+			err := RegisterRecordingRules(recordingRules)
+			Expect(err).To(BeNil())
+
+			recordingRules = []RecordingRule{
+				{
+					MetricsOpts: operatormetrics.MetricOpts{Name: "ExampleRecordingRule1"},
+					Expr:        intstr.FromString("sum(rate(http_requests_total[10m]))"),
+				},
+			}
+
+			err = RegisterRecordingRules(recordingRules)
+			Expect(err).To(BeNil())
+
+			registeredRules := ListRecordingRules()
+			Expect(registeredRules).To(HaveLen(2))
+			Expect(registeredRules[0].Expr.String()).To(Equal("sum(rate(http_requests_total[10m]))"))
+			Expect(registeredRules[1].Expr.String()).To(Equal("sum(rate(http_requests_total[5m]))"))
+		})
+	})
+
+	Context("Alert Registration", func() {
+		It("should register alerts without error", func() {
+			alerts := []promv1.Rule{
+				{
+					Alert: "ExampleAlert1",
+					Expr:  intstr.FromString("sum(rate(http_requests_total[1m])) > 100"),
+					Labels: map[string]string{
+						"severity": "critical",
+					},
+					Annotations: map[string]string{
+						"summary":     "High request rate",
+						"description": "The request rate is too high.",
+					},
+				},
+				{
+					Alert: "ExampleAlert2",
+					Expr:  intstr.FromString("sum(rate(http_requests_total[5m])) > 100"),
+					Labels: map[string]string{
+						"severity": "warning",
+					},
+					Annotations: map[string]string{
+						"summary":     "Moderate request rate",
+						"description": "The request rate is moderately high.",
+					},
+				},
+			}
+
+			err := RegisterAlerts(alerts)
+			Expect(err).To(BeNil())
+
+			registeredAlerts := ListAlerts()
+			Expect(registeredAlerts).To(ConsistOf(alerts))
+		})
+
+		It("should replace alerts with the same name in the same RegisterAlerts call", func() {
+			alerts := []promv1.Rule{
+				{
+					Alert: "ExampleAlert1",
+					Expr:  intstr.FromString("sum(rate(http_requests_total[1m])) > 100"),
+					Labels: map[string]string{
+						"severity": "critical",
+					},
+					Annotations: map[string]string{
+						"summary":     "High request rate",
+						"description": "The request rate is too high.",
+					},
+				},
+				{
+					Alert: "ExampleAlert1",
+					Expr:  intstr.FromString("sum(rate(http_requests_total[1m])) > 200"),
+					Labels: map[string]string{
+						"severity": "critical",
+					},
+					Annotations: map[string]string{
+						"summary":     "High request rate",
+						"description": "The request rate is too high.",
+					},
+				},
+			}
+
+			err := RegisterAlerts(alerts)
+			Expect(err).To(BeNil())
+
+			registeredAlerts := ListAlerts()
+			Expect(registeredAlerts).To(HaveLen(1))
+			Expect(registeredAlerts[0].Expr.String()).To(Equal("sum(rate(http_requests_total[1m])) > 200"))
+		})
+
+		It("should replace alerts with the same name in different RegisterAlerts calls", func() {
+			alerts := []promv1.Rule{
+				{
+					Alert: "ExampleAlert1",
+					Expr:  intstr.FromString("sum(rate(http_requests_total[1m])) > 100"),
+					Labels: map[string]string{
+						"severity": "critical",
+					},
+					Annotations: map[string]string{
+						"summary":     "High request rate",
+						"description": "The request rate is too high.",
+					},
+				},
+			}
+
+			err := RegisterAlerts(alerts)
+			Expect(err).To(BeNil())
+
+			alerts = []promv1.Rule{
+				{
+					Alert: "ExampleAlert1",
+					Expr:  intstr.FromString("sum(rate(http_requests_total[1m])) > 200"),
+					Labels: map[string]string{
+						"severity": "critical",
+					},
+					Annotations: map[string]string{
+						"summary":     "High request rate",
+						"description": "The request rate is too high.",
+					},
+				},
+			}
+
+			err = RegisterAlerts(alerts)
+			Expect(err).To(BeNil())
+
+			registeredAlerts := ListAlerts()
+			Expect(registeredAlerts).To(HaveLen(1))
+			Expect(registeredAlerts[0].Expr.String()).To(Equal("sum(rate(http_requests_total[1m])) > 200"))
+		})
+	})
+
+	Context("Clean Registry", func() {
+		It("should clean registry without error", func() {
+			recordingRules := []RecordingRule{
+				{
+					MetricsOpts: operatormetrics.MetricOpts{Name: "ExampleRecordingRule1"},
+					Expr:        intstr.FromString("sum(rate(http_requests_total[5m]))"),
+				},
+			}
+
+			alerts := []promv1.Rule{
+				{
+					Alert: "ExampleAlert1",
+					Expr:  intstr.FromString("sum(rate(http_requests_total[1m])) > 100"),
+				},
+			}
+
+			err := RegisterRecordingRules(recordingRules)
+			Expect(err).To(BeNil())
+			registeredRules := ListRecordingRules()
+			Expect(registeredRules).To(ConsistOf(recordingRules))
+
+			err = RegisterAlerts(alerts)
+			Expect(err).To(BeNil())
+			registeredAlerts := ListAlerts()
+			Expect(registeredAlerts).To(ConsistOf(alerts))
+
+			err = CleanRegistry()
+			Expect(err).To(BeNil())
+
+			registeredRules = ListRecordingRules()
+			Expect(registeredRules).To(BeEmpty())
+			registeredAlerts = ListAlerts()
+			Expect(registeredAlerts).To(BeEmpty())
+		})
+	})
+})

--- a/pkg/operatorrules/operatorrules_suite_test.go
+++ b/pkg/operatorrules/operatorrules_suite_test.go
@@ -1,4 +1,4 @@
-package operatorrules
+package operatorrules_test
 
 import (
 	"testing"

--- a/pkg/operatorrules/prometheusrules.go
+++ b/pkg/operatorrules/prometheusrules.go
@@ -11,8 +11,8 @@ import (
 )
 
 // BuildPrometheusRule builds a PrometheusRule object from the registered recording rules and alerts.
-func BuildPrometheusRule(name, namespace string, labels map[string]string) (*promv1.PrometheusRule, error) {
-	spec, err := buildPrometheusRuleSpec()
+func (r *Registry) BuildPrometheusRule(name, namespace string, labels map[string]string) (*promv1.PrometheusRule, error) {
+	spec, err := r.buildPrometheusRuleSpec()
 	if err != nil {
 		return nil, err
 	}
@@ -31,20 +31,20 @@ func BuildPrometheusRule(name, namespace string, labels map[string]string) (*pro
 	}, nil
 }
 
-func buildPrometheusRuleSpec() (*promv1.PrometheusRuleSpec, error) {
+func (r *Registry) buildPrometheusRuleSpec() (*promv1.PrometheusRuleSpec, error) {
 	var groups []promv1.RuleGroup
 
-	if len(operatorRegistry.registeredRecordingRules) != 0 {
+	if len(r.registeredRecordingRules) != 0 {
 		groups = append(groups, promv1.RuleGroup{
 			Name:  "recordingRules.rules",
-			Rules: buildRecordingRulesRules(),
+			Rules: r.buildRecordingRulesRules(),
 		})
 	}
 
-	if len(operatorRegistry.registeredAlerts) != 0 {
+	if len(r.registeredAlerts) != 0 {
 		groups = append(groups, promv1.RuleGroup{
 			Name:  "alerts.rules",
-			Rules: ListAlerts(),
+			Rules: r.ListAlerts(),
 		})
 	}
 
@@ -55,10 +55,10 @@ func buildPrometheusRuleSpec() (*promv1.PrometheusRuleSpec, error) {
 	return &promv1.PrometheusRuleSpec{Groups: groups}, nil
 }
 
-func buildRecordingRulesRules() []promv1.Rule {
+func (r *Registry) buildRecordingRulesRules() []promv1.Rule {
 	var rules []promv1.Rule
 
-	for _, recordingRule := range operatorRegistry.registeredRecordingRules {
+	for _, recordingRule := range r.registeredRecordingRules {
 		rules = append(rules, promv1.Rule{
 			Record: recordingRule.MetricsOpts.Name,
 			Expr:   recordingRule.Expr,

--- a/pkg/operatorrules/prometheusrules_test.go
+++ b/pkg/operatorrules/prometheusrules_test.go
@@ -1,4 +1,4 @@
-package operatorrules
+package operatorrules_test
 
 import (
 	. "github.com/onsi/ginkgo/v2"
@@ -9,11 +9,14 @@ import (
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 
 	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
+	"github.com/machadovilaca/operator-observability/pkg/operatorrules"
 )
 
 var _ = Describe("PrometheusRules", func() {
 	Context("Building resource", func() {
-		var recordingRules = []RecordingRule{
+		var or *operatorrules.Registry
+
+		var recordingRules = []operatorrules.RecordingRule{
 			{
 				MetricsOpts: operatormetrics.MetricOpts{
 					Name:        "number_of_pods",
@@ -69,17 +72,17 @@ var _ = Describe("PrometheusRules", func() {
 		}
 
 		BeforeEach(func() {
-			operatorRegistry = newRegistry()
+			or = operatorrules.NewRegistry()
 
-			err := RegisterRecordingRules(recordingRules)
+			err := or.RegisterRecordingRules(recordingRules)
 			Expect(err).To(Not(HaveOccurred()))
 
-			err = RegisterAlerts(alerts)
+			err = or.RegisterAlerts(alerts)
 			Expect(err).To(Not(HaveOccurred()))
 		})
 
 		It("should build PrometheusRule with valid input", func() {
-			rules, err := BuildPrometheusRule(
+			rules, err := or.BuildPrometheusRule(
 				"guestbook-operator-prometheus-rules",
 				"default",
 				map[string]string{"app": "guestbook-operator"},
@@ -104,7 +107,7 @@ var _ = Describe("PrometheusRules", func() {
 		})
 
 		It("should sort the recording rules of alerts by name ('Record')", func() {
-			rules, err := BuildPrometheusRule(
+			rules, err := or.BuildPrometheusRule(
 				"guestbook-operator-prometheus-rules",
 				"default",
 				map[string]string{"app": "guestbook-operator"},
@@ -125,7 +128,7 @@ var _ = Describe("PrometheusRules", func() {
 		})
 
 		It("should sort the list of alerts by name ('Alert')", func() {
-			rules, err := BuildPrometheusRule(
+			rules, err := or.BuildPrometheusRule(
 				"guestbook-operator-prometheus-rules",
 				"default",
 				map[string]string{"app": "guestbook-operator"},

--- a/pkg/operatorrules/registry.go
+++ b/pkg/operatorrules/registry.go
@@ -7,26 +7,24 @@ import (
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
 
-var operatorRegistry = newRegistry()
-
-type operatorRegisterer struct {
+type Registry struct {
 	registeredRecordingRules map[string]RecordingRule
 	registeredAlerts         map[string]promv1.Rule
 }
 
-func newRegistry() operatorRegisterer {
-	return operatorRegisterer{
+func NewRegistry() *Registry {
+	return &Registry{
 		registeredRecordingRules: map[string]RecordingRule{},
 		registeredAlerts:         map[string]promv1.Rule{},
 	}
 }
 
 // RegisterRecordingRules registers the given recording rules.
-func RegisterRecordingRules(recordingRules ...[]RecordingRule) error {
+func (r *Registry) RegisterRecordingRules(recordingRules ...[]RecordingRule) error {
 	for _, recordingRuleList := range recordingRules {
 		for _, recordingRule := range recordingRuleList {
 			key := recordingRule.MetricsOpts.Name + ":" + recordingRule.Expr.String()
-			operatorRegistry.registeredRecordingRules[key] = recordingRule
+			r.registeredRecordingRules[key] = recordingRule
 		}
 	}
 
@@ -34,10 +32,10 @@ func RegisterRecordingRules(recordingRules ...[]RecordingRule) error {
 }
 
 // RegisterAlerts registers the given alerts.
-func RegisterAlerts(alerts ...[]promv1.Rule) error {
+func (r *Registry) RegisterAlerts(alerts ...[]promv1.Rule) error {
 	for _, alertList := range alerts {
 		for _, alert := range alertList {
-			operatorRegistry.registeredAlerts[alert.Alert] = alert
+			r.registeredAlerts[alert.Alert] = alert
 		}
 	}
 
@@ -45,9 +43,9 @@ func RegisterAlerts(alerts ...[]promv1.Rule) error {
 }
 
 // ListRecordingRules returns the registered recording rules.
-func ListRecordingRules() []RecordingRule {
+func (r *Registry) ListRecordingRules() []RecordingRule {
 	var rules []RecordingRule
-	for _, rule := range operatorRegistry.registeredRecordingRules {
+	for _, rule := range r.registeredRecordingRules {
 		rules = append(rules, rule)
 	}
 
@@ -62,9 +60,9 @@ func ListRecordingRules() []RecordingRule {
 }
 
 // ListAlerts returns the registered alerts.
-func ListAlerts() []promv1.Rule {
+func (r *Registry) ListAlerts() []promv1.Rule {
 	var alerts []promv1.Rule
-	for _, alert := range operatorRegistry.registeredAlerts {
+	for _, alert := range r.registeredAlerts {
 		alerts = append(alerts, alert)
 	}
 
@@ -73,10 +71,4 @@ func ListAlerts() []promv1.Rule {
 	})
 
 	return alerts
-}
-
-// CleanRegistry removes all registered rules and alerts.
-func CleanRegistry() error {
-	operatorRegistry = newRegistry()
-	return nil
 }

--- a/pkg/operatorrules/registry_test.go
+++ b/pkg/operatorrules/registry_test.go
@@ -1,4 +1,4 @@
-package operatorrules
+package operatorrules_test
 
 import (
 	. "github.com/onsi/ginkgo/v2"
@@ -9,16 +9,19 @@ import (
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 
 	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
+	"github.com/machadovilaca/operator-observability/pkg/operatorrules"
 )
 
 var _ = Describe("OperatorRules", func() {
+	var or *operatorrules.Registry
+
 	BeforeEach(func() {
-		operatorRegistry = newRegistry()
+		or = operatorrules.NewRegistry()
 	})
 
 	Context("RecordingRule Registration", func() {
 		It("should register recording rules without error", func() {
-			recordingRules := []RecordingRule{
+			recordingRules := []operatorrules.RecordingRule{
 				{
 					MetricsOpts: operatormetrics.MetricOpts{Name: "ExampleRecordingRule1"},
 					Expr:        intstr.FromString("sum(rate(http_requests_total[5m]))"),
@@ -29,15 +32,15 @@ var _ = Describe("OperatorRules", func() {
 				},
 			}
 
-			err := RegisterRecordingRules(recordingRules)
+			err := or.RegisterRecordingRules(recordingRules)
 			Expect(err).To(BeNil())
 
-			registeredRules := ListRecordingRules()
+			registeredRules := or.ListRecordingRules()
 			Expect(registeredRules).To(ConsistOf(recordingRules))
 		})
 
 		It("should replace recording rule with the same name and expression", func() {
-			recordingRules := []RecordingRule{
+			recordingRules := []operatorrules.RecordingRule{
 				{
 					MetricsOpts: operatormetrics.MetricOpts{Name: "ExampleRecordingRule1"},
 					Expr:        intstr.FromString("sum(rate(http_requests_total[5m]))"),
@@ -48,36 +51,36 @@ var _ = Describe("OperatorRules", func() {
 				},
 			}
 
-			err := RegisterRecordingRules(recordingRules)
+			err := or.RegisterRecordingRules(recordingRules)
 			Expect(err).To(BeNil())
 
-			registeredRules := ListRecordingRules()
+			registeredRules := or.ListRecordingRules()
 			Expect(registeredRules).To(HaveLen(1))
 			Expect(registeredRules[0].Expr.String()).To(Equal("sum(rate(http_requests_total[5m]))"))
 		})
 
 		It("should create 2 recording rules when registered with the same name but different expressions", func() {
-			recordingRules := []RecordingRule{
+			recordingRules := []operatorrules.RecordingRule{
 				{
 					MetricsOpts: operatormetrics.MetricOpts{Name: "ExampleRecordingRule1"},
 					Expr:        intstr.FromString("sum(rate(http_requests_total[5m]))"),
 				},
 			}
 
-			err := RegisterRecordingRules(recordingRules)
+			err := or.RegisterRecordingRules(recordingRules)
 			Expect(err).To(BeNil())
 
-			recordingRules = []RecordingRule{
+			recordingRules = []operatorrules.RecordingRule{
 				{
 					MetricsOpts: operatormetrics.MetricOpts{Name: "ExampleRecordingRule1"},
 					Expr:        intstr.FromString("sum(rate(http_requests_total[10m]))"),
 				},
 			}
 
-			err = RegisterRecordingRules(recordingRules)
+			err = or.RegisterRecordingRules(recordingRules)
 			Expect(err).To(BeNil())
 
-			registeredRules := ListRecordingRules()
+			registeredRules := or.ListRecordingRules()
 			Expect(registeredRules).To(HaveLen(2))
 			Expect(registeredRules[0].Expr.String()).To(Equal("sum(rate(http_requests_total[10m]))"))
 			Expect(registeredRules[1].Expr.String()).To(Equal("sum(rate(http_requests_total[5m]))"))
@@ -111,10 +114,10 @@ var _ = Describe("OperatorRules", func() {
 				},
 			}
 
-			err := RegisterAlerts(alerts)
+			err := or.RegisterAlerts(alerts)
 			Expect(err).To(BeNil())
 
-			registeredAlerts := ListAlerts()
+			registeredAlerts := or.ListAlerts()
 			Expect(registeredAlerts).To(ConsistOf(alerts))
 		})
 
@@ -144,10 +147,10 @@ var _ = Describe("OperatorRules", func() {
 				},
 			}
 
-			err := RegisterAlerts(alerts)
+			err := or.RegisterAlerts(alerts)
 			Expect(err).To(BeNil())
 
-			registeredAlerts := ListAlerts()
+			registeredAlerts := or.ListAlerts()
 			Expect(registeredAlerts).To(HaveLen(1))
 			Expect(registeredAlerts[0].Expr.String()).To(Equal("sum(rate(http_requests_total[1m])) > 200"))
 		})
@@ -167,7 +170,7 @@ var _ = Describe("OperatorRules", func() {
 				},
 			}
 
-			err := RegisterAlerts(alerts)
+			err := or.RegisterAlerts(alerts)
 			Expect(err).To(BeNil())
 
 			alerts = []promv1.Rule{
@@ -184,48 +187,12 @@ var _ = Describe("OperatorRules", func() {
 				},
 			}
 
-			err = RegisterAlerts(alerts)
+			err = or.RegisterAlerts(alerts)
 			Expect(err).To(BeNil())
 
-			registeredAlerts := ListAlerts()
+			registeredAlerts := or.ListAlerts()
 			Expect(registeredAlerts).To(HaveLen(1))
 			Expect(registeredAlerts[0].Expr.String()).To(Equal("sum(rate(http_requests_total[1m])) > 200"))
-		})
-	})
-
-	Context("Clean Registry", func() {
-		It("should clean registry without error", func() {
-			recordingRules := []RecordingRule{
-				{
-					MetricsOpts: operatormetrics.MetricOpts{Name: "ExampleRecordingRule1"},
-					Expr:        intstr.FromString("sum(rate(http_requests_total[5m]))"),
-				},
-			}
-
-			alerts := []promv1.Rule{
-				{
-					Alert: "ExampleAlert1",
-					Expr:  intstr.FromString("sum(rate(http_requests_total[1m])) > 100"),
-				},
-			}
-
-			err := RegisterRecordingRules(recordingRules)
-			Expect(err).To(BeNil())
-			registeredRules := ListRecordingRules()
-			Expect(registeredRules).To(ConsistOf(recordingRules))
-
-			err = RegisterAlerts(alerts)
-			Expect(err).To(BeNil())
-			registeredAlerts := ListAlerts()
-			Expect(registeredAlerts).To(ConsistOf(alerts))
-
-			err = CleanRegistry()
-			Expect(err).To(BeNil())
-
-			registeredRules = ListRecordingRules()
-			Expect(registeredRules).To(BeEmpty())
-			registeredAlerts = ListAlerts()
-			Expect(registeredAlerts).To(BeEmpty())
 		})
 	})
 })


### PR DESCRIPTION
Before this PR operator rules were stored in a global variable. This prevented a project from having multiple instances with different alerts and recording rules. This PR follows a structured approach where library users create a new instance of the registry where they can register the alerts and recording rules and old functions are now instance methods.

To keep backward compatibility `pkg/operatorrules/compatibility.go` was created that delegates previous functions to the instance methods of a global variable. This is deprecated and should be removed in the future.