### PR TITLE
Compile tests as separate package

### DIFF
--- a/pkg/docs/docs_suite_test.go
+++ b/pkg/docs/docs_suite_test.go
@@ -1,4 +1,4 @@
-package docs
+package docs_test
 
 import (
 	"testing"

--- a/pkg/docs/metrics_test.go
+++ b/pkg/docs/metrics_test.go
@@ -1,4 +1,4 @@
-package docs
+package docs_test
 
 import (
 	"strings"
@@ -8,6 +8,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"github.com/machadovilaca/operator-observability/pkg/docs"
 	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
 	"github.com/machadovilaca/operator-observability/pkg/operatorrules"
 )
@@ -67,7 +68,7 @@ var metrics = []operatormetrics.Metric{
 var _ = Describe("Metrics Documentation", func() {
 	Context("Metrics and Recording Rules", func() {
 		It("Checks that metrics and recording rules are documented", func() {
-			docMetrics := BuildMetricsDocs(metrics, recordingRules)
+			docMetrics := docs.BuildMetricsDocs(metrics, recordingRules)
 			Expect(docMetrics).To(ContainSubstring("CExampleRecordingRule"))
 			Expect(docMetrics).To(ContainSubstring("AExampleRecordingRule"))
 			Expect(docMetrics).To(ContainSubstring("BExampleGauge"))
@@ -75,7 +76,7 @@ var _ = Describe("Metrics Documentation", func() {
 		})
 
 		It("Checks that metrics and recording rules are documented with custom template", func() {
-			templateDocMetrics := BuildMetricsDocsWithCustomTemplate(metrics, recordingRules, tpl)
+			templateDocMetrics := docs.BuildMetricsDocsWithCustomTemplate(metrics, recordingRules, tpl)
 			Expect(templateDocMetrics).To(ContainSubstring("metrics-doc-test-title"))
 			Expect(templateDocMetrics).To(ContainSubstring("metrics-doc-test-body"))
 			Expect(templateDocMetrics).To(ContainSubstring("CExampleRecordingRule"))
@@ -85,7 +86,7 @@ var _ = Describe("Metrics Documentation", func() {
 		})
 
 		It("Checks that the metrics doc is sorted by metrics and recording rules name", func() {
-			templateDocMetrics := BuildMetricsDocsWithCustomTemplate(metrics, recordingRules, tpl)
+			templateDocMetrics := docs.BuildMetricsDocsWithCustomTemplate(metrics, recordingRules, tpl)
 			indexOfA := strings.Index(templateDocMetrics, "AExampleRecordingRule")
 			indexOfB := strings.Index(templateDocMetrics, "BExampleGauge")
 			indexOfC := strings.Index(templateDocMetrics, "CExampleRecordingRule")
@@ -97,7 +98,7 @@ var _ = Describe("Metrics Documentation", func() {
 		})
 
 		It("Checks that metrics are documented in the right format", func() {
-			templateDocMetrics := BuildMetricsDocsWithCustomTemplate(metrics, nil, tpl)
+			templateDocMetrics := docs.BuildMetricsDocsWithCustomTemplate(metrics, nil, tpl)
 			Expect(templateDocMetrics).To(ContainSubstring("BExampleGauge\ntest doc gauge. Type: Gauge."))
 			Expect(templateDocMetrics).To(ContainSubstring("[ALPHA in 1.4.0] test doc counterVec. Type: Counter."))
 		})

--- a/pkg/operatormetrics/collector.go
+++ b/pkg/operatormetrics/collector.go
@@ -40,7 +40,7 @@ func (c Collector) hash() string {
 
 func (c Collector) Describe(ch chan<- *prometheus.Desc) {
 	for _, cm := range c.Metrics {
-		cm.getCollector().Describe(ch)
+		cm.GetCollector().Describe(ch)
 	}
 }
 

--- a/pkg/operatormetrics/collector_test.go
+++ b/pkg/operatormetrics/collector_test.go
@@ -1,4 +1,4 @@
-package operatormetrics
+package operatormetrics_test
 
 import (
 	"time"
@@ -9,19 +9,21 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
 )
 
 var _ = Describe("Collector", func() {
 	var (
-		testCounterOpts = MetricOpts{
+		testCounterOpts = operatormetrics.MetricOpts{
 			Name: "collector_test_counter",
 			Help: "A test counter",
 		}
-		testGaugeOpts = MetricOpts{
+		testGaugeOpts = operatormetrics.MetricOpts{
 			Name: "collector_test_gauge",
 			Help: "A test gauge",
 		}
-		testCounterOpts2 = MetricOpts{
+		testCounterOpts2 = operatormetrics.MetricOpts{
 			Name: "collector_test_counter_2",
 			Help: "A test counter",
 		}
@@ -29,25 +31,25 @@ var _ = Describe("Collector", func() {
 
 	Describe("Collect", func() {
 		BeforeEach(func() {
-			err := CleanRegistry()
+			err := operatormetrics.CleanRegistry()
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should collect metrics from registered collectors", func() {
-			counter := NewCounter(testCounterOpts)
-			gauge := NewGauge(testGaugeOpts)
+			counter := operatormetrics.NewCounter(testCounterOpts)
+			gauge := operatormetrics.NewGauge(testGaugeOpts)
 
-			collector := Collector{
-				Metrics: []Metric{counter, gauge},
-				CollectCallback: func() []CollectorResult {
-					return []CollectorResult{
+			collector := operatormetrics.Collector{
+				Metrics: []operatormetrics.Metric{counter, gauge},
+				CollectCallback: func() []operatormetrics.CollectorResult {
+					return []operatormetrics.CollectorResult{
 						{Metric: counter, Labels: nil, Value: 5},
 						{Metric: gauge, Labels: nil, Value: 10},
 					}
 				},
 			}
 
-			err := RegisterCollector(collector)
+			err := operatormetrics.RegisterCollector(collector)
 			Expect(err).NotTo(HaveOccurred())
 
 			ch := make(chan prometheus.Metric, 2)
@@ -61,12 +63,12 @@ var _ = Describe("Collector", func() {
 		})
 
 		It("should skip unregistered collectors", func() {
-			counter := NewCounter(testCounterOpts2)
+			counter := operatormetrics.NewCounter(testCounterOpts2)
 
-			collector := Collector{
-				Metrics: []Metric{counter},
-				CollectCallback: func() []CollectorResult {
-					return []CollectorResult{
+			collector := operatormetrics.Collector{
+				Metrics: []operatormetrics.Metric{counter},
+				CollectCallback: func() []operatormetrics.CollectorResult {
+					return []operatormetrics.CollectorResult{
 						{Metric: counter, Labels: nil, Value: 5},
 					}
 				},
@@ -79,12 +81,12 @@ var _ = Describe("Collector", func() {
 		})
 
 		It("should collect metrics with const labels added on collection time", func() {
-			counter := NewCounter(testCounterOpts)
+			counter := operatormetrics.NewCounter(testCounterOpts)
 
-			collector := Collector{
-				Metrics: []Metric{counter},
-				CollectCallback: func() []CollectorResult {
-					return []CollectorResult{
+			collector := operatormetrics.Collector{
+				Metrics: []operatormetrics.Metric{counter},
+				CollectCallback: func() []operatormetrics.CollectorResult {
+					return []operatormetrics.CollectorResult{
 						{
 							Metric: counter,
 							Labels: nil,
@@ -97,7 +99,7 @@ var _ = Describe("Collector", func() {
 				},
 			}
 
-			err := RegisterCollector(collector)
+			err := operatormetrics.RegisterCollector(collector)
 			Expect(err).NotTo(HaveOccurred())
 
 			ch := make(chan prometheus.Metric, 1)
@@ -110,18 +112,18 @@ var _ = Describe("Collector", func() {
 		})
 
 		It("should collect metrics with custom timestamps", func() {
-			counter := NewCounter(testCounterOpts)
+			counter := operatormetrics.NewCounter(testCounterOpts)
 
-			collector := Collector{
-				Metrics: []Metric{counter},
-				CollectCallback: func() []CollectorResult {
-					return []CollectorResult{
+			collector := operatormetrics.Collector{
+				Metrics: []operatormetrics.Metric{counter},
+				CollectCallback: func() []operatormetrics.CollectorResult {
+					return []operatormetrics.CollectorResult{
 						{Metric: counter, Labels: nil, Value: 5, Timestamp: time.UnixMilli(1000)},
 					}
 				},
 			}
 
-			err := RegisterCollector(collector)
+			err := operatormetrics.RegisterCollector(collector)
 			Expect(err).NotTo(HaveOccurred())
 
 			ch := make(chan prometheus.Metric, 1)

--- a/pkg/operatormetrics/counter.go
+++ b/pkg/operatormetrics/counter.go
@@ -31,6 +31,6 @@ func (c *Counter) GetBaseType() MetricType {
 	return CounterType
 }
 
-func (c *Counter) getCollector() prometheus.Collector {
+func (c *Counter) GetCollector() prometheus.Collector {
 	return c.Counter
 }

--- a/pkg/operatormetrics/counter_vec.go
+++ b/pkg/operatormetrics/counter_vec.go
@@ -33,6 +33,6 @@ func (c *CounterVec) GetBaseType() MetricType {
 	return CounterType
 }
 
-func (c *CounterVec) getCollector() prometheus.Collector {
+func (c *CounterVec) GetCollector() prometheus.Collector {
 	return c.CounterVec
 }

--- a/pkg/operatormetrics/gauge.go
+++ b/pkg/operatormetrics/gauge.go
@@ -31,6 +31,6 @@ func (c *Gauge) GetBaseType() MetricType {
 	return GaugeType
 }
 
-func (c *Gauge) getCollector() prometheus.Collector {
+func (c *Gauge) GetCollector() prometheus.Collector {
 	return c.Gauge
 }

--- a/pkg/operatormetrics/gauge_vec.go
+++ b/pkg/operatormetrics/gauge_vec.go
@@ -33,6 +33,6 @@ func (c *GaugeVec) GetBaseType() MetricType {
 	return GaugeType
 }
 
-func (c *GaugeVec) getCollector() prometheus.Collector {
+func (c *GaugeVec) GetCollector() prometheus.Collector {
 	return c.GaugeVec
 }

--- a/pkg/operatormetrics/histogram.go
+++ b/pkg/operatormetrics/histogram.go
@@ -46,6 +46,6 @@ func (c *Histogram) GetBaseType() MetricType {
 	return HistogramType
 }
 
-func (c *Histogram) getCollector() prometheus.Collector {
+func (c *Histogram) GetCollector() prometheus.Collector {
 	return c.Histogram
 }

--- a/pkg/operatormetrics/histogram_vec.go
+++ b/pkg/operatormetrics/histogram_vec.go
@@ -37,6 +37,6 @@ func (c *HistogramVec) GetBaseType() MetricType {
 	return HistogramType
 }
 
-func (c *HistogramVec) getCollector() prometheus.Collector {
+func (c *HistogramVec) GetCollector() prometheus.Collector {
 	return c.HistogramVec
 }

--- a/pkg/operatormetrics/metric.go
+++ b/pkg/operatormetrics/metric.go
@@ -15,8 +15,7 @@ type Metric interface {
 	GetOpts() MetricOpts
 	GetType() MetricType
 	GetBaseType() MetricType
-
-	getCollector() prometheus.Collector
+	GetCollector() prometheus.Collector
 }
 
 type MetricType string

--- a/pkg/operatormetrics/metric_test.go
+++ b/pkg/operatormetrics/metric_test.go
@@ -1,4 +1,4 @@
-package operatormetrics
+package operatormetrics_test
 
 import (
 	. "github.com/onsi/ginkgo/v2"
@@ -6,47 +6,47 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	io_prometheus_client "github.com/prometheus/client_model/go"
+
+	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
 )
 
 var _ = Describe("Metrics", func() {
 	var (
-		testCounterOpts = MetricOpts{
+		testCounterOpts = operatormetrics.MetricOpts{
 			Name: "test_counter",
 			Help: "A test counter",
 		}
-		testCounterVecOpts = MetricOpts{
-			Name:   "test_counter_vec",
-			Help:   "A test counter vec",
-			labels: []string{"label1", "label2"},
+		testCounterVecOpts = operatormetrics.MetricOpts{
+			Name: "test_counter_vec",
+			Help: "A test counter vec",
 		}
-		testGaugeOpts = MetricOpts{
+		testGaugeOpts = operatormetrics.MetricOpts{
 			Name: "test_gauge",
 			Help: "A test gauge",
 		}
-		testGaugeVecOpts = MetricOpts{
-			Name:   "test_gauge_vec",
-			Help:   "A test gauge vec",
-			labels: []string{"label1", "label2"},
+		testGaugeVecOpts = operatormetrics.MetricOpts{
+			Name: "test_gauge_vec",
+			Help: "A test gauge vec",
 		}
-		testHistogramOpts = MetricOpts{
+		testHistogramOpts = operatormetrics.MetricOpts{
 			Name: "test_histogram",
 			Help: "A test histogram",
 		}
 		testHistogramHistogramOpts = prometheus.HistogramOpts{
 			Buckets: prometheus.LinearBuckets(0, 10, 10),
 		}
-		testHistogramVecOpts = MetricOpts{
+		testHistogramVecOpts = operatormetrics.MetricOpts{
 			Name: "test_histogram_vec",
 			Help: "A test histogram vec",
 		}
-		testSummaryOpts = MetricOpts{
+		testSummaryOpts = operatormetrics.MetricOpts{
 			Name: "test_summary",
 			Help: "A test summary",
 		}
 		testSummarySummaryOpts = prometheus.SummaryOpts{
 			Objectives: map[float64]float64{0.1: 0.1, 0.2: 0.2, 0.3: 0.3, 0.4: 0.4, 0.5: 0.5},
 		}
-		testSummaryVecOpts = MetricOpts{
+		testSummaryVecOpts = operatormetrics.MetricOpts{
 			Name: "test_summary_vec",
 			Help: "A test summary vec",
 		}
@@ -54,81 +54,47 @@ var _ = Describe("Metrics", func() {
 
 	Describe("Metric Constructors", func() {
 		It("should create a new Counter with the provided options", func() {
-			counter := NewCounter(testCounterOpts)
+			counter := operatormetrics.NewCounter(testCounterOpts)
 			Expect(counter).NotTo(BeNil())
 			Expect(counter.GetOpts()).To(Equal(testCounterOpts))
-			Expect(counter.GetType()).To(Equal(CounterType))
-		})
-
-		It("should create a new CounterVec with the provided options and labels", func() {
-			labels := []string{"label1", "label2"}
-			counterVec := NewCounterVec(testCounterVecOpts, labels)
-			Expect(counterVec).NotTo(BeNil())
-			Expect(counterVec.GetOpts()).To(Equal(testCounterVecOpts))
-			Expect(counterVec.GetType()).To(Equal(CounterVecType))
+			Expect(counter.GetType()).To(Equal(operatormetrics.CounterType))
 		})
 
 		It("should create a new Gauge with the provided options", func() {
-			gauge := NewGauge(testGaugeOpts)
+			gauge := operatormetrics.NewGauge(testGaugeOpts)
 			Expect(gauge).NotTo(BeNil())
 			Expect(gauge.GetOpts()).To(Equal(testGaugeOpts))
-			Expect(gauge.GetType()).To(Equal(GaugeType))
-		})
-
-		It("should create a new GaugeVec with the provided options and labels", func() {
-			labels := []string{"label1", "label2"}
-			gaugeVec := NewGaugeVec(testGaugeVecOpts, labels)
-			Expect(gaugeVec).NotTo(BeNil())
-			Expect(gaugeVec.GetOpts()).To(Equal(testGaugeVecOpts))
-			Expect(gaugeVec.GetType()).To(Equal(GaugeVecType))
+			Expect(gauge.GetType()).To(Equal(operatormetrics.GaugeType))
 		})
 
 		It("should create a new Histogram with the provided options", func() {
-			histogram := NewHistogram(testHistogramOpts, testHistogramHistogramOpts)
+			histogram := operatormetrics.NewHistogram(testHistogramOpts, testHistogramHistogramOpts)
 			Expect(histogram).NotTo(BeNil())
 			Expect(histogram.GetOpts()).To(Equal(testHistogramOpts))
-			Expect(histogram.GetType()).To(Equal(HistogramType))
+			Expect(histogram.GetType()).To(Equal(operatormetrics.HistogramType))
 			Expect(histogram.GetHistogramOpts()).To(Equal(testHistogramHistogramOpts))
 		})
 
-		It("should create a new HistogramVec with the provided options and labels", func() {
-			labels := []string{"label1", "label2"}
-			histogramVec := NewHistogramVec(testHistogramVecOpts, testHistogramHistogramOpts, labels)
-			Expect(histogramVec).NotTo(BeNil())
-			Expect(histogramVec.GetOpts()).To(Equal(testHistogramVecOpts))
-			Expect(histogramVec.GetType()).To(Equal(HistogramVecType))
-			Expect(histogramVec.GetHistogramOpts()).To(Equal(testHistogramHistogramOpts))
-		})
-
 		It("should create a new Summary with the provided options", func() {
-			summary := NewSummary(testSummaryOpts, testSummarySummaryOpts)
+			summary := operatormetrics.NewSummary(testSummaryOpts, testSummarySummaryOpts)
 			Expect(summary).NotTo(BeNil())
 			Expect(summary.GetOpts()).To(Equal(testSummaryOpts))
-			Expect(summary.GetType()).To(Equal(SummaryType))
+			Expect(summary.GetType()).To(Equal(operatormetrics.SummaryType))
 			Expect(summary.GetSummaryOpts()).To(Equal(testSummarySummaryOpts))
-		})
-
-		It("should create a new SummaryVec with the provided options and labels", func() {
-			labels := []string{"label1", "label2"}
-			summaryVec := NewSummaryVec(testSummaryVecOpts, testSummarySummaryOpts, labels)
-			Expect(summaryVec).NotTo(BeNil())
-			Expect(summaryVec.GetOpts()).To(Equal(testSummaryVecOpts))
-			Expect(summaryVec.GetType()).To(Equal(SummaryVecType))
-			Expect(summaryVec.GetSummaryOpts()).To(Equal(testSummarySummaryOpts))
 		})
 	})
 
 	Describe("Counter and CounterVec", func() {
 		It("should increment the counter and counter with labels", func() {
-			counter := NewCounter(testCounterOpts)
-			counterVec := NewCounterVec(testCounterVecOpts, []string{"label1"})
+			counter := operatormetrics.NewCounter(testCounterOpts)
+			counterVec := operatormetrics.NewCounterVec(testCounterVecOpts, []string{"label1"})
 
 			counter.Inc()
 			counterVec.WithLabelValues("value1").Add(2)
 
 			ch := make(chan prometheus.Metric, 2)
-			counter.getCollector().Collect(ch)
-			counterVec.getCollector().Collect(ch)
+			counter.GetCollector().Collect(ch)
+			counterVec.GetCollector().Collect(ch)
 
 			metricCounter := <-ch
 			metricCounterVec := <-ch
@@ -150,15 +116,15 @@ var _ = Describe("Metrics", func() {
 
 	Describe("Gauge and GaugeVec", func() {
 		It("should set the gauge and gauge with labels", func() {
-			gauge := NewGauge(testGaugeOpts)
-			gaugeVec := NewGaugeVec(testGaugeVecOpts, []string{"label1"})
+			gauge := operatormetrics.NewGauge(testGaugeOpts)
+			gaugeVec := operatormetrics.NewGaugeVec(testGaugeVecOpts, []string{"label1"})
 
 			gauge.Set(42)
 			gaugeVec.WithLabelValues("value1").Set(43)
 
 			ch := make(chan prometheus.Metric, 2)
-			gauge.getCollector().Collect(ch)
-			gaugeVec.getCollector().Collect(ch)
+			gauge.GetCollector().Collect(ch)
+			gaugeVec.GetCollector().Collect(ch)
 
 			metricGauge := <-ch
 			metricGaugeVec := <-ch
@@ -180,15 +146,15 @@ var _ = Describe("Metrics", func() {
 
 	Describe("Histogram and HistogramVec", func() {
 		It("should observe the histogram and histogram with labels", func() {
-			histogram := NewHistogram(testHistogramOpts, testHistogramHistogramOpts)
-			histogramVec := NewHistogramVec(testHistogramVecOpts, testHistogramHistogramOpts, []string{"label1"})
+			histogram := operatormetrics.NewHistogram(testHistogramOpts, testHistogramHistogramOpts)
+			histogramVec := operatormetrics.NewHistogramVec(testHistogramVecOpts, testHistogramHistogramOpts, []string{"label1"})
 
 			histogram.Observe(42)
 			histogramVec.WithLabelValues("value1").Observe(43)
 
 			ch := make(chan prometheus.Metric, 2)
-			histogram.getCollector().Collect(ch)
-			histogramVec.getCollector().Collect(ch)
+			histogram.GetCollector().Collect(ch)
+			histogramVec.GetCollector().Collect(ch)
 
 			metricHistogram := <-ch
 			metricHistogramVec := <-ch
@@ -210,15 +176,15 @@ var _ = Describe("Metrics", func() {
 
 	Describe("Summary and SummaryVec", func() {
 		It("should observe the summary and summary with labels", func() {
-			summary := NewSummary(testSummaryOpts, testSummarySummaryOpts)
-			summaryVec := NewSummaryVec(testSummaryVecOpts, testSummarySummaryOpts, []string{"label1"})
+			summary := operatormetrics.NewSummary(testSummaryOpts, testSummarySummaryOpts)
+			summaryVec := operatormetrics.NewSummaryVec(testSummaryVecOpts, testSummarySummaryOpts, []string{"label1"})
 
 			summary.Observe(42)
 			summaryVec.WithLabelValues("value1").Observe(43)
 
 			ch := make(chan prometheus.Metric, 2)
-			summary.getCollector().Collect(ch)
-			summaryVec.getCollector().Collect(ch)
+			summary.GetCollector().Collect(ch)
+			summaryVec.GetCollector().Collect(ch)
 
 			metricSummary := <-ch
 			metricSummaryVec := <-ch

--- a/pkg/operatormetrics/operatormetrics_suite_test.go
+++ b/pkg/operatormetrics/operatormetrics_suite_test.go
@@ -1,4 +1,4 @@
-package operatormetrics
+package operatormetrics_test
 
 import (
 	"testing"

--- a/pkg/operatormetrics/summary.go
+++ b/pkg/operatormetrics/summary.go
@@ -46,6 +46,6 @@ func (c *Summary) GetBaseType() MetricType {
 	return SummaryType
 }
 
-func (c *Summary) getCollector() prometheus.Collector {
+func (c *Summary) GetCollector() prometheus.Collector {
 	return c.Summary
 }

--- a/pkg/operatormetrics/summary_vec.go
+++ b/pkg/operatormetrics/summary_vec.go
@@ -37,6 +37,6 @@ func (c *SummaryVec) GetBaseType() MetricType {
 	return SummaryType
 }
 
-func (c *SummaryVec) getCollector() prometheus.Collector {
+func (c *SummaryVec) GetCollector() prometheus.Collector {
 	return c.SummaryVec
 }

--- a/pkg/operatormetrics/wrapper_registry.go
+++ b/pkg/operatormetrics/wrapper_registry.go
@@ -122,7 +122,7 @@ func metricExists(metric Metric) bool {
 }
 
 func unregisterMetric(metric Metric) error {
-	if succeeded := Unregister(metric.getCollector()); succeeded {
+	if succeeded := Unregister(metric.GetCollector()); succeeded {
 		delete(operatorRegistry.registeredMetrics, metric.GetOpts().Name)
 		return nil
 	}
@@ -131,7 +131,7 @@ func unregisterMetric(metric Metric) error {
 }
 
 func registerMetric(metric Metric) error {
-	err := Register(metric.getCollector())
+	err := Register(metric.GetCollector())
 	if err != nil {
 		return err
 	}

--- a/pkg/operatorrules/compatibility_test.go
+++ b/pkg/operatorrules/compatibility_test.go
@@ -1,4 +1,4 @@
-package operatorrules
+package operatorrules_test
 
 import (
 	. "github.com/onsi/ginkgo/v2"
@@ -9,16 +9,18 @@ import (
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 
 	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
+	"github.com/machadovilaca/operator-observability/pkg/operatorrules"
 )
 
 var _ = Describe("OperatorRules", func() {
 	BeforeEach(func() {
-		operatorRegistry = NewRegistry()
+		err := operatorrules.CleanRegistry()
+		Expect(err).To(Not(HaveOccurred()))
 	})
 
 	Context("RecordingRule Registration", func() {
 		It("should register recording rules without error", func() {
-			recordingRules := []RecordingRule{
+			recordingRules := []operatorrules.RecordingRule{
 				{
 					MetricsOpts: operatormetrics.MetricOpts{Name: "ExampleRecordingRule1"},
 					Expr:        intstr.FromString("sum(rate(http_requests_total[5m]))"),
@@ -29,15 +31,15 @@ var _ = Describe("OperatorRules", func() {
 				},
 			}
 
-			err := RegisterRecordingRules(recordingRules)
+			err := operatorrules.RegisterRecordingRules(recordingRules)
 			Expect(err).To(BeNil())
 
-			registeredRules := ListRecordingRules()
+			registeredRules := operatorrules.ListRecordingRules()
 			Expect(registeredRules).To(ConsistOf(recordingRules))
 		})
 
 		It("should replace recording rule with the same name and expression", func() {
-			recordingRules := []RecordingRule{
+			recordingRules := []operatorrules.RecordingRule{
 				{
 					MetricsOpts: operatormetrics.MetricOpts{Name: "ExampleRecordingRule1"},
 					Expr:        intstr.FromString("sum(rate(http_requests_total[5m]))"),
@@ -48,36 +50,36 @@ var _ = Describe("OperatorRules", func() {
 				},
 			}
 
-			err := RegisterRecordingRules(recordingRules)
+			err := operatorrules.RegisterRecordingRules(recordingRules)
 			Expect(err).To(BeNil())
 
-			registeredRules := ListRecordingRules()
+			registeredRules := operatorrules.ListRecordingRules()
 			Expect(registeredRules).To(HaveLen(1))
 			Expect(registeredRules[0].Expr.String()).To(Equal("sum(rate(http_requests_total[5m]))"))
 		})
 
 		It("should create 2 recording rules when registered with the same name but different expressions", func() {
-			recordingRules := []RecordingRule{
+			recordingRules := []operatorrules.RecordingRule{
 				{
 					MetricsOpts: operatormetrics.MetricOpts{Name: "ExampleRecordingRule1"},
 					Expr:        intstr.FromString("sum(rate(http_requests_total[5m]))"),
 				},
 			}
 
-			err := RegisterRecordingRules(recordingRules)
+			err := operatorrules.RegisterRecordingRules(recordingRules)
 			Expect(err).To(BeNil())
 
-			recordingRules = []RecordingRule{
+			recordingRules = []operatorrules.RecordingRule{
 				{
 					MetricsOpts: operatormetrics.MetricOpts{Name: "ExampleRecordingRule1"},
 					Expr:        intstr.FromString("sum(rate(http_requests_total[10m]))"),
 				},
 			}
 
-			err = RegisterRecordingRules(recordingRules)
+			err = operatorrules.RegisterRecordingRules(recordingRules)
 			Expect(err).To(BeNil())
 
-			registeredRules := ListRecordingRules()
+			registeredRules := operatorrules.ListRecordingRules()
 			Expect(registeredRules).To(HaveLen(2))
 			Expect(registeredRules[0].Expr.String()).To(Equal("sum(rate(http_requests_total[10m]))"))
 			Expect(registeredRules[1].Expr.String()).To(Equal("sum(rate(http_requests_total[5m]))"))
@@ -111,10 +113,10 @@ var _ = Describe("OperatorRules", func() {
 				},
 			}
 
-			err := RegisterAlerts(alerts)
+			err := operatorrules.RegisterAlerts(alerts)
 			Expect(err).To(BeNil())
 
-			registeredAlerts := ListAlerts()
+			registeredAlerts := operatorrules.ListAlerts()
 			Expect(registeredAlerts).To(ConsistOf(alerts))
 		})
 
@@ -144,10 +146,10 @@ var _ = Describe("OperatorRules", func() {
 				},
 			}
 
-			err := RegisterAlerts(alerts)
+			err := operatorrules.RegisterAlerts(alerts)
 			Expect(err).To(BeNil())
 
-			registeredAlerts := ListAlerts()
+			registeredAlerts := operatorrules.ListAlerts()
 			Expect(registeredAlerts).To(HaveLen(1))
 			Expect(registeredAlerts[0].Expr.String()).To(Equal("sum(rate(http_requests_total[1m])) > 200"))
 		})
@@ -167,7 +169,7 @@ var _ = Describe("OperatorRules", func() {
 				},
 			}
 
-			err := RegisterAlerts(alerts)
+			err := operatorrules.RegisterAlerts(alerts)
 			Expect(err).To(BeNil())
 
 			alerts = []promv1.Rule{
@@ -184,10 +186,10 @@ var _ = Describe("OperatorRules", func() {
 				},
 			}
 
-			err = RegisterAlerts(alerts)
+			err = operatorrules.RegisterAlerts(alerts)
 			Expect(err).To(BeNil())
 
-			registeredAlerts := ListAlerts()
+			registeredAlerts := operatorrules.ListAlerts()
 			Expect(registeredAlerts).To(HaveLen(1))
 			Expect(registeredAlerts[0].Expr.String()).To(Equal("sum(rate(http_requests_total[1m])) > 200"))
 		})
@@ -195,7 +197,7 @@ var _ = Describe("OperatorRules", func() {
 
 	Context("Clean Registry", func() {
 		It("should clean registry without error", func() {
-			recordingRules := []RecordingRule{
+			recordingRules := []operatorrules.RecordingRule{
 				{
 					MetricsOpts: operatormetrics.MetricOpts{Name: "ExampleRecordingRule1"},
 					Expr:        intstr.FromString("sum(rate(http_requests_total[5m]))"),
@@ -209,22 +211,22 @@ var _ = Describe("OperatorRules", func() {
 				},
 			}
 
-			err := RegisterRecordingRules(recordingRules)
+			err := operatorrules.RegisterRecordingRules(recordingRules)
 			Expect(err).To(BeNil())
-			registeredRules := ListRecordingRules()
+			registeredRules := operatorrules.ListRecordingRules()
 			Expect(registeredRules).To(ConsistOf(recordingRules))
 
-			err = RegisterAlerts(alerts)
+			err = operatorrules.RegisterAlerts(alerts)
 			Expect(err).To(BeNil())
-			registeredAlerts := ListAlerts()
+			registeredAlerts := operatorrules.ListAlerts()
 			Expect(registeredAlerts).To(ConsistOf(alerts))
 
-			err = CleanRegistry()
+			err = operatorrules.CleanRegistry()
 			Expect(err).To(BeNil())
 
-			registeredRules = ListRecordingRules()
+			registeredRules = operatorrules.ListRecordingRules()
 			Expect(registeredRules).To(BeEmpty())
-			registeredAlerts = ListAlerts()
+			registeredAlerts = operatorrules.ListAlerts()
 			Expect(registeredAlerts).To(BeEmpty())
 		})
 	})

--- a/pkg/testutil/alert_custom_validation_test.go
+++ b/pkg/testutil/alert_custom_validation_test.go
@@ -1,4 +1,4 @@
-package testutil
+package testutil_test
 
 import (
 	. "github.com/onsi/ginkgo/v2"
@@ -6,13 +6,15 @@ import (
 
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/machadovilaca/operator-observability/pkg/testutil"
 )
 
 var _ = Describe("Custom Validators", func() {
-	var linter *Linter
+	var linter *testutil.Linter
 
 	BeforeEach(func() {
-		linter = New()
+		linter = testutil.New()
 	})
 
 	Context("Custom Alert Validations", func() {
@@ -32,8 +34,13 @@ var _ = Describe("Custom Validators", func() {
 					"runbook_url": "example/runbook/url",
 				},
 			}
-			linter.AddCustomAlertValidations(ValidateAlertNameLength, ValidateAlertHasDescriptionAnnotation,
-				ValidateAlertRunbookURLAnnotation, ValidateAlertHealthImpactLabel, ValidateAlertPartOfAndComponentLabels)
+			linter.AddCustomAlertValidations(
+				testutil.ValidateAlertNameLength,
+				testutil.ValidateAlertHasDescriptionAnnotation,
+				testutil.ValidateAlertRunbookURLAnnotation,
+				testutil.ValidateAlertHealthImpactLabel,
+				testutil.ValidateAlertPartOfAndComponentLabels,
+			)
 			problems := linter.LintAlert(alert)
 			Expect(problems).To(BeEmpty())
 		})
@@ -49,7 +56,7 @@ var _ = Describe("Custom Validators", func() {
 					"summary": "Example summary",
 				},
 			}
-			linter.AddCustomAlertValidations(ValidateAlertNameLength)
+			linter.AddCustomAlertValidations(testutil.ValidateAlertNameLength)
 			problems := linter.LintAlert(alert)
 			Expect(problems).To(HaveLen(1))
 			Expect(problems[0].Description).To(ContainSubstring("alert name exceeds 50 characters"))
@@ -66,7 +73,7 @@ var _ = Describe("Custom Validators", func() {
 					"summary": "Example summary",
 				},
 			}
-			linter.AddCustomAlertValidations(ValidateAlertHasDescriptionAnnotation)
+			linter.AddCustomAlertValidations(testutil.ValidateAlertHasDescriptionAnnotation)
 			problems := linter.LintAlert(alert)
 			Expect(problems).To(HaveLen(1))
 			Expect(problems[0].Description).To(ContainSubstring("alert must have a description annotation"))
@@ -83,7 +90,7 @@ var _ = Describe("Custom Validators", func() {
 					"summary": "Example summary",
 				},
 			}
-			linter.AddCustomAlertValidations(ValidateAlertRunbookURLAnnotation)
+			linter.AddCustomAlertValidations(testutil.ValidateAlertRunbookURLAnnotation)
 			problems := linter.LintAlert(alert)
 			Expect(problems).To(HaveLen(1))
 			Expect(problems[0].Description).To(ContainSubstring("alert must have a runbook_url annotation"))
@@ -101,7 +108,7 @@ var _ = Describe("Custom Validators", func() {
 					"summary": "Example summary",
 				},
 			}
-			linter.AddCustomAlertValidations(ValidateAlertHealthImpactLabel)
+			linter.AddCustomAlertValidations(testutil.ValidateAlertHealthImpactLabel)
 			problems := linter.LintAlert(alert)
 			Expect(problems).To(HaveLen(1))
 			Expect(problems[0].Description).To(ContainSubstring("alert must have a operator_health_impact label with value critical, warning, or none"))
@@ -118,7 +125,7 @@ var _ = Describe("Custom Validators", func() {
 					"summary": "Example summary",
 				},
 			}
-			linter.AddCustomAlertValidations(ValidateAlertPartOfAndComponentLabels)
+			linter.AddCustomAlertValidations(testutil.ValidateAlertPartOfAndComponentLabels)
 			problems := linter.LintAlert(alert)
 			Expect(problems).To(HaveLen(2))
 			Expect(problems[0].Description).To(ContainSubstring("alert must have a kubernetes_operator_part_of label"))

--- a/pkg/testutil/alert_validation_test.go
+++ b/pkg/testutil/alert_validation_test.go
@@ -1,4 +1,4 @@
-package testutil
+package testutil_test
 
 import (
 	. "github.com/onsi/ginkgo/v2"
@@ -6,13 +6,15 @@ import (
 
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/machadovilaca/operator-observability/pkg/testutil"
 )
 
 var _ = Describe("Default Validators", func() {
-	var linter *Linter
+	var linter *testutil.Linter
 
 	BeforeEach(func() {
-		linter = New()
+		linter = testutil.New()
 	})
 
 	Context("Alert Validation", func() {

--- a/pkg/testutil/recording_rule_validation_test.go
+++ b/pkg/testutil/recording_rule_validation_test.go
@@ -1,4 +1,4 @@
-package testutil
+package testutil_test
 
 import (
 	. "github.com/onsi/ginkgo/v2"
@@ -8,13 +8,14 @@ import (
 
 	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
 	"github.com/machadovilaca/operator-observability/pkg/operatorrules"
+	"github.com/machadovilaca/operator-observability/pkg/testutil"
 )
 
 var _ = Describe("Validators", func() {
-	var linter *Linter
+	var linter *testutil.Linter
 
 	BeforeEach(func() {
-		linter = New()
+		linter = testutil.New()
 	})
 
 	Context("RecordingRule Validation", func() {


### PR DESCRIPTION
Add the `_test` prefix to all package test files to ensure tests are compiled as a separate package from the source.

Source: https://pkg.go.dev/cmd/go@master#hdr-Test_packages -> "Test files that declare a package with the suffix "_test" will be compiled as a separate package, and then linked and run with the main test binary."