### PR TITLE
Allow alerts with the same name and different expressions

### DIFF
--- a/pkg/operatorrules/compatibility_test.go
+++ b/pkg/operatorrules/compatibility_test.go
@@ -120,29 +120,19 @@ var _ = Describe("OperatorRules", func() {
 			Expect(registeredAlerts).To(ConsistOf(alerts))
 		})
 
-		It("should replace alerts with the same name in the same RegisterAlerts call", func() {
+		It("should replace alerts with the same name and same expression in the same RegisterAlerts call", func() {
 			alerts := []promv1.Rule{
 				{
 					Alert: "ExampleAlert1",
 					Expr:  intstr.FromString("sum(rate(http_requests_total[1m])) > 100"),
-					Labels: map[string]string{
-						"severity": "critical",
-					},
-					Annotations: map[string]string{
-						"summary":     "High request rate",
-						"description": "The request rate is too high.",
-					},
 				},
 				{
 					Alert: "ExampleAlert1",
 					Expr:  intstr.FromString("sum(rate(http_requests_total[1m])) > 200"),
-					Labels: map[string]string{
-						"severity": "critical",
-					},
-					Annotations: map[string]string{
-						"summary":     "High request rate",
-						"description": "The request rate is too high.",
-					},
+				},
+				{
+					Alert: "ExampleAlert1",
+					Expr:  intstr.FromString("sum(rate(http_requests_total[1m])) > 100"),
 				},
 			}
 
@@ -150,22 +140,16 @@ var _ = Describe("OperatorRules", func() {
 			Expect(err).To(BeNil())
 
 			registeredAlerts := operatorrules.ListAlerts()
-			Expect(registeredAlerts).To(HaveLen(1))
-			Expect(registeredAlerts[0].Expr.String()).To(Equal("sum(rate(http_requests_total[1m])) > 200"))
+			Expect(registeredAlerts).To(HaveLen(2))
+			Expect(registeredAlerts[0].Expr.String()).To(Equal("sum(rate(http_requests_total[1m])) > 100"))
+			Expect(registeredAlerts[1].Expr.String()).To(Equal("sum(rate(http_requests_total[1m])) > 200"))
 		})
 
-		It("should replace alerts with the same name in different RegisterAlerts calls", func() {
+		It("should replace alerts with the same name and same expression in different RegisterAlerts calls", func() {
 			alerts := []promv1.Rule{
 				{
 					Alert: "ExampleAlert1",
 					Expr:  intstr.FromString("sum(rate(http_requests_total[1m])) > 100"),
-					Labels: map[string]string{
-						"severity": "critical",
-					},
-					Annotations: map[string]string{
-						"summary":     "High request rate",
-						"description": "The request rate is too high.",
-					},
 				},
 			}
 
@@ -176,13 +160,10 @@ var _ = Describe("OperatorRules", func() {
 				{
 					Alert: "ExampleAlert1",
 					Expr:  intstr.FromString("sum(rate(http_requests_total[1m])) > 200"),
-					Labels: map[string]string{
-						"severity": "critical",
-					},
-					Annotations: map[string]string{
-						"summary":     "High request rate",
-						"description": "The request rate is too high.",
-					},
+				},
+				{
+					Alert: "ExampleAlert1",
+					Expr:  intstr.FromString("sum(rate(http_requests_total[1m])) > 100"),
 				},
 			}
 
@@ -190,8 +171,9 @@ var _ = Describe("OperatorRules", func() {
 			Expect(err).To(BeNil())
 
 			registeredAlerts := operatorrules.ListAlerts()
-			Expect(registeredAlerts).To(HaveLen(1))
-			Expect(registeredAlerts[0].Expr.String()).To(Equal("sum(rate(http_requests_total[1m])) > 200"))
+			Expect(registeredAlerts).To(HaveLen(2))
+			Expect(registeredAlerts[0].Expr.String()).To(Equal("sum(rate(http_requests_total[1m])) > 100"))
+			Expect(registeredAlerts[1].Expr.String()).To(Equal("sum(rate(http_requests_total[1m])) > 200"))
 		})
 	})
 

--- a/pkg/operatorrules/registry.go
+++ b/pkg/operatorrules/registry.go
@@ -35,7 +35,8 @@ func (r *Registry) RegisterRecordingRules(recordingRules ...[]RecordingRule) err
 func (r *Registry) RegisterAlerts(alerts ...[]promv1.Rule) error {
 	for _, alertList := range alerts {
 		for _, alert := range alertList {
-			r.registeredAlerts[alert.Alert] = alert
+			key := alert.Alert + ":" + alert.Expr.String()
+			r.registeredAlerts[key] = alert
 		}
 	}
 

--- a/pkg/operatorrules/registry_test.go
+++ b/pkg/operatorrules/registry_test.go
@@ -121,29 +121,19 @@ var _ = Describe("OperatorRules", func() {
 			Expect(registeredAlerts).To(ConsistOf(alerts))
 		})
 
-		It("should replace alerts with the same name in the same RegisterAlerts call", func() {
+		It("should replace alerts with the same name and same expression in the same RegisterAlerts call", func() {
 			alerts := []promv1.Rule{
 				{
 					Alert: "ExampleAlert1",
 					Expr:  intstr.FromString("sum(rate(http_requests_total[1m])) > 100"),
-					Labels: map[string]string{
-						"severity": "critical",
-					},
-					Annotations: map[string]string{
-						"summary":     "High request rate",
-						"description": "The request rate is too high.",
-					},
 				},
 				{
 					Alert: "ExampleAlert1",
 					Expr:  intstr.FromString("sum(rate(http_requests_total[1m])) > 200"),
-					Labels: map[string]string{
-						"severity": "critical",
-					},
-					Annotations: map[string]string{
-						"summary":     "High request rate",
-						"description": "The request rate is too high.",
-					},
+				},
+				{
+					Alert: "ExampleAlert1",
+					Expr:  intstr.FromString("sum(rate(http_requests_total[1m])) > 100"),
 				},
 			}
 
@@ -151,22 +141,16 @@ var _ = Describe("OperatorRules", func() {
 			Expect(err).To(BeNil())
 
 			registeredAlerts := or.ListAlerts()
-			Expect(registeredAlerts).To(HaveLen(1))
-			Expect(registeredAlerts[0].Expr.String()).To(Equal("sum(rate(http_requests_total[1m])) > 200"))
+			Expect(registeredAlerts).To(HaveLen(2))
+			Expect(registeredAlerts[0].Expr.String()).To(Equal("sum(rate(http_requests_total[1m])) > 100"))
+			Expect(registeredAlerts[1].Expr.String()).To(Equal("sum(rate(http_requests_total[1m])) > 200"))
 		})
 
-		It("should replace alerts with the same name in different RegisterAlerts calls", func() {
+		It("should replace alerts with the same name and same expression in different RegisterAlerts calls", func() {
 			alerts := []promv1.Rule{
 				{
 					Alert: "ExampleAlert1",
 					Expr:  intstr.FromString("sum(rate(http_requests_total[1m])) > 100"),
-					Labels: map[string]string{
-						"severity": "critical",
-					},
-					Annotations: map[string]string{
-						"summary":     "High request rate",
-						"description": "The request rate is too high.",
-					},
 				},
 			}
 
@@ -177,13 +161,10 @@ var _ = Describe("OperatorRules", func() {
 				{
 					Alert: "ExampleAlert1",
 					Expr:  intstr.FromString("sum(rate(http_requests_total[1m])) > 200"),
-					Labels: map[string]string{
-						"severity": "critical",
-					},
-					Annotations: map[string]string{
-						"summary":     "High request rate",
-						"description": "The request rate is too high.",
-					},
+				},
+				{
+					Alert: "ExampleAlert1",
+					Expr:  intstr.FromString("sum(rate(http_requests_total[1m])) > 100"),
 				},
 			}
 
@@ -191,8 +172,9 @@ var _ = Describe("OperatorRules", func() {
 			Expect(err).To(BeNil())
 
 			registeredAlerts := or.ListAlerts()
-			Expect(registeredAlerts).To(HaveLen(1))
-			Expect(registeredAlerts[0].Expr.String()).To(Equal("sum(rate(http_requests_total[1m])) > 200"))
+			Expect(registeredAlerts).To(HaveLen(2))
+			Expect(registeredAlerts[0].Expr.String()).To(Equal("sum(rate(http_requests_total[1m])) > 100"))
+			Expect(registeredAlerts[1].Expr.String()).To(Equal("sum(rate(http_requests_total[1m])) > 200"))
 		})
 	})
 })


### PR DESCRIPTION
Alerts with the same name, but different expressions and different criticality should be able to exist