### PR TITLE
Also sort alerts by Expr to ensure order when same name

### DIFF
--- a/pkg/operatorrules/registry.go
+++ b/pkg/operatorrules/registry.go
@@ -68,7 +68,10 @@ func (r *Registry) ListAlerts() []promv1.Rule {
 	}
 
 	slices.SortFunc(alerts, func(a, b promv1.Rule) int {
-		return cmp.Compare(a.Alert, b.Alert)
+		aKey := a.Alert + ":" + a.Expr.String()
+		bKey := b.Alert + ":" + b.Expr.String()
+
+		return cmp.Compare(aKey, bKey)
 	})
 
 	return alerts

--- a/pkg/operatorrules/registry_test.go
+++ b/pkg/operatorrules/registry_test.go
@@ -176,5 +176,35 @@ var _ = Describe("OperatorRules", func() {
 			Expect(registeredAlerts[0].Expr.String()).To(Equal("sum(rate(http_requests_total[1m])) > 100"))
 			Expect(registeredAlerts[1].Expr.String()).To(Equal("sum(rate(http_requests_total[1m])) > 200"))
 		})
+
+		It("should create 2 alerts when registered with the same name but different expressions", func() {
+			alerts := []promv1.Rule{
+				{
+					Alert: "ExampleAlert1",
+					Expr:  intstr.FromString("sum(rate(http_requests_total[1m])) > 100"),
+				},
+			}
+
+			err := or.RegisterAlerts(alerts)
+			Expect(err).To(BeNil())
+
+			alerts = []promv1.Rule{
+				{
+					Alert: "ExampleAlert1",
+					Expr:  intstr.FromString("sum(rate(http_requests_total[1m])) > 200"),
+				},
+			}
+
+			err = or.RegisterAlerts(alerts)
+			Expect(err).To(BeNil())
+
+			By("Ensuring the output is consistent")
+			for i := 0; i < 10; i++ {
+				registeredAlerts := or.ListAlerts()
+				Expect(registeredAlerts).To(HaveLen(2))
+				Expect(registeredAlerts[0].Expr.String()).To(Equal("sum(rate(http_requests_total[1m])) > 100"))
+				Expect(registeredAlerts[1].Expr.String()).To(Equal("sum(rate(http_requests_total[1m])) > 200"))
+			}
+		})
 	})
 })


### PR DESCRIPTION
We should sort the alerts also by Expr to ensure when there are multiple alerts created with the same name but different expressions, the output is always the same for the same state.