### PR TITLE
fetch_metrics: introduce MetricsFetcher interface

### DIFF
--- a/pkg/testutil/fetch_metrics_test.go
+++ b/pkg/testutil/fetch_metrics_test.go
@@ -2,6 +2,7 @@ package testutil_test
 
 import (
 	_ "embed"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -15,6 +16,7 @@ var metricsEndpointResponse string
 
 var _ = Describe("FetchMetrics", func() {
 	var server *ghttp.Server
+	var metricsFetcher testutil.MetricsFetcher
 
 	BeforeEach(func() {
 		server = ghttp.NewServer()
@@ -27,6 +29,8 @@ var _ = Describe("FetchMetrics", func() {
 				ghttp.VerifyRequest("GET", path),
 				ghttp.RespondWithPtr(&statusCode, &metricsEndpointResponse),
 			))
+
+		metricsFetcher = testutil.NewMetricsFetcher(server.URL() + "/metrics")
 	})
 
 	AfterEach(func() {
@@ -34,8 +38,12 @@ var _ = Describe("FetchMetrics", func() {
 	})
 
 	It("Should fetch all metrics with a given name", func() {
-		mr, err := testutil.FetchMetric(server.URL()+"/metrics", "kubevirt_vm_count_total")
+		metricsFetcher.AddNameFilter("kubevirt_vm_count_total")
+		metrics, err := metricsFetcher.Run()
 		Expect(err).ToNot(HaveOccurred())
+
+		Expect(metrics).To(HaveKey("kubevirt_vm_count_total"))
+		mr := metrics["kubevirt_vm_count_total"]
 
 		Expect(mr).To(HaveLen(2))
 		Expect(mr[0].Name).To(Equal("kubevirt_vm_count_total"))
@@ -43,11 +51,15 @@ var _ = Describe("FetchMetrics", func() {
 	})
 
 	It("Should fetch all metrics with a given name and a single label pair", func() {
-		mr, err := testutil.FetchMetric(server.URL()+"/metrics", "kubevirt_migration_count", "status", "failed")
+		metricsFetcher.AddLabelFilter("status", "failed")
+		metricsFetcher.AddNameFilter("kubevirt_migration_count")
+		metrics, err := metricsFetcher.Run()
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(mr).To(HaveLen(2))
+		Expect(metrics).To(HaveKey("kubevirt_migration_count"))
+		mr := metrics["kubevirt_migration_count"]
 
+		Expect(mr).To(HaveLen(2))
 		Expect(mr[0].Name).To(Equal("kubevirt_migration_count"))
 		Expect(mr[0].Labels).To(HaveKeyWithValue("node", "node01"))
 		Expect(mr[0].Labels).To(HaveKeyWithValue("status", "failed"))
@@ -60,8 +72,13 @@ var _ = Describe("FetchMetrics", func() {
 	})
 
 	It("Should fetch all metrics with a given name and multiple label pairs", func() {
-		mr, err := testutil.FetchMetric(server.URL()+"/metrics", "kubevirt_vm_memory_usage_bytes", "namespace", "default", "vm_name", "vm1")
+		metricsFetcher.AddLabelFilter("namespace", "default", "vm_name", "vm1")
+		metricsFetcher.AddNameFilter("kubevirt_vm_memory_usage_bytes")
+		metrics, err := metricsFetcher.Run()
 		Expect(err).ToNot(HaveOccurred())
+
+		Expect(metrics).To(HaveKey("kubevirt_vm_memory_usage_bytes"))
+		mr := metrics["kubevirt_vm_memory_usage_bytes"]
 
 		Expect(mr).To(HaveLen(1))
 		Expect(mr[0].Name).To(Equal("kubevirt_vm_memory_usage_bytes"))
@@ -69,4 +86,49 @@ var _ = Describe("FetchMetrics", func() {
 		Expect(mr[0].Labels).To(HaveKeyWithValue("vm_name", "vm1"))
 		Expect(mr[0].Value).To(Equal(204800.0))
 	})
+
+	It("Should return an empty map when no metrics match the filter", func() {
+		metricsFetcher.AddNameFilter("non_existent_metric")
+		metrics, err := metricsFetcher.Run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(metrics).To(BeEmpty())
+	})
+
+	It("Should return only metrics after a specific timestamp", func() {
+		metricsFetcher.AddTimestampAfterFilter(time.Unix(1738861783, 0))
+		metricsFetcher.AddNameFilter("kubevirt_vm_memory_usage_bytes")
+		metrics, err := metricsFetcher.Run()
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(metrics).To(HaveKey("kubevirt_vm_memory_usage_bytes"))
+		mr := metrics["kubevirt_vm_memory_usage_bytes"]
+
+		Expect(mr).To(HaveLen(1))
+		Expect(mr[0].Labels).To(HaveKeyWithValue("vm_name", "vm4"))
+		Expect(mr[0].Value).To(Equal(2009600.0))
+	})
+
+	It("Should return only metrics before a specific timestamp", func() {
+		metricsFetcher.AddTimestampBeforeFilter(time.Unix(1738861783, 0))
+		metricsFetcher.AddNameFilter("kubevirt_vm_memory_usage_bytes")
+		metrics, err := metricsFetcher.Run()
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(metrics).To(HaveKey("kubevirt_vm_memory_usage_bytes"))
+		mr := metrics["kubevirt_vm_memory_usage_bytes"]
+
+		Expect(mr).To(HaveLen(1))
+		Expect(mr[0].Labels).To(HaveKeyWithValue("vm_name", "vm3"))
+		Expect(mr[0].Value).To(Equal(1004800.0))
+	})
+
+	It("Should fetch metrics with given prefix name", func() {
+		metricsFetcher.AddNameFilter("kubevirt_vm_")
+		metrics, err := metricsFetcher.Run()
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(metrics).ToNot(BeEmpty())
+		Expect(metrics).To(HaveLen(2))
+	})
+
 })

--- a/pkg/testutil/testdata/metrics.txt
+++ b/pkg/testutil/testdata/metrics.txt
@@ -14,3 +14,9 @@ kubevirt_migration_count{namespace="default",node="node02",status="failed"} 1
 # TYPE kubevirt_vm_memory_usage_bytes gauge
 kubevirt_vm_memory_usage_bytes{namespace="default",vm_name="vm1"} 204800
 kubevirt_vm_memory_usage_bytes{namespace="default",vm_name="vm2"} 409600
+kubevirt_vm_memory_usage_bytes{namespace="default",vm_name="vm3"} 1004800 1738861782
+kubevirt_vm_memory_usage_bytes{namespace="default",vm_name="vm4"} 2009600 1738861784
+
+# HELP go_info Information about the Go environment.
+# TYPE go_info gauge - Added this to make sure we correctly parse metrics that contains white spaces in the labels
+go_info{version="go1.23.4 X:nocoverageredesign"} 1


### PR DESCRIPTION
This PR tries to enhance the fetch_metrics logic by introducing an interface 

```
type MetricsFetcher interface {
	AddNameFilter(name string)
	AddLabelFilter(labelsKeyValue ...string)
	AddTimestampAfterFilter(ts time.Time)
	AddTimestampBeforeFilter(ts time.Time)
	Run() (map[string][]MetricResult, error)
	LoadMetrics(payload string) (map[string][]MetricResult, error)
}
``` 

usage example:

```
fetcher = testutil.NewMetricsFetcher(server.URL() + "/metrics")
fetcher.AddNameFilter("kubevirt_vm_count_total")
metrics, err := fetcher.Run()
```